### PR TITLE
feat: link using env.js file if exists

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,8 @@
 ### react-native link scripts
 There are scripts added to be run using react-native link that will modify you Android and iOS projects so you don't have to manually set it up. This is to allow use inside libraries that don't expose the native project files like https://github.com/brandingbrand/flagship.
 
-You can configure you redirect scheme using your package.json file of you react-native app project.
+You can configure you redirect scheme in one of two places.
+If you are inside a Flagship application, you can use your env.[ENV].js file to define it. You can use also use the package.json file of you react-native app project. The format should follow the scheme below.
 ```json
 {
   "react-native-app-auth": {

--- a/scripts/rnpm-postlink.js
+++ b/scripts/rnpm-postlink.js
@@ -1,7 +1,17 @@
+const fs = require('fs');
 const path = require('path');
 const packageJson = require(path.join(process.cwd(), 'package.json'));
 
-const redirectScheme = packageJson['react-native-app-auth'] && packageJson['react-native-app-auth'].redirectScheme;
+// read redirect scheme from env/env.js or package.json
+let redirectScheme = null;
+const envFilePath = path.join(process.cwd(), 'env', 'env.js');
+if (fs.existsSync(envFilePath)) {
+  const envInfo = require(envFilePath);
+  redirectScheme = envInfo['react-native-app-auth'] && envInfo['react-native-app-auth'].redirectScheme;
+}
+if (!redirectScheme) {
+  redirectScheme = packageJson['react-native-app-auth'] && packageJson['react-native-app-auth'].redirectScheme;
+}
 
 if (redirectScheme) {
   require('./rnpm-postlink-android')(redirectScheme);


### PR DESCRIPTION
use env/env.js for redirectScheme if file exists instead of package.json
this allows for multiple environment when used inside a @brandingbrand/flagship application


