### PR TITLE
fix: pin appauth version to 1.2.0

### DIFF
--- a/react-native-app-auth.podspec
+++ b/react-native-app-auth.podspec
@@ -13,5 +13,5 @@ Pod::Spec.new do |s|
   s.source_files  = "ios/*.{h,m}"
 
   s.dependency "React"
-  s.dependency "AppAuth"
+  s.dependency "AppAuth", "1.2.0"
 end


### PR DESCRIPTION
## Description
pin version so it works with xCode 10

## Test
* run in app with xCode 10
*ER: compiles

