### PR TITLE
checkIfAndroidExists Check if android exists for init iOS

### DIFF
--- a/scripts/rnpm-postlink-android.js
+++ b/scripts/rnpm-postlink-android.js
@@ -4,60 +4,59 @@ const appBuildGradlePath = path.join('android', 'app', 'build.gradle');
 const appManifestPath = path.join('android', 'app', 'src', 'main', 'AndroidManifest.xml');
 const projectSettings = path.join('android', 'settings.gradle');
 module.exports = function install(redirectSchemes) {
-    // If only initing iOS android won't exist
-    if (fs.existsSync(appBuildGradlePath)) {
-      let buildGradleContents = fs.readFileSync(appBuildGradlePath, 'utf8');
+  // If only initing iOS android won't exist
+  if (fs.existsSync(appBuildGradlePath)) {
+    let buildGradleContents = fs.readFileSync(appBuildGradlePath, 'utf8');
+    // 1) Upgrade support version to 25.3.1
+    buildGradleContents = buildGradleContents.replace(
+      'com.android.support:appcompat-v7:23.0.1', 
+      'com.android.support:appcompat-v7:25.3.1');
 
-      // 1) Upgrade support version to 25.3.1
-      buildGradleContents = buildGradleContents.replace(
-        'com.android.support:appcompat-v7:23.0.1', 
-        'com.android.support:appcompat-v7:25.3.1');
-  
-      // 2) Upgrade compile version
-      buildGradleContents = buildGradleContents.replace(
-        'compileSdkVersion 24', 
-        'compileSdkVersion 25');
-  
-      // 3) fix scoped package name in app/build.gradle
-      buildGradleContents = buildGradleContents.replace(
-        /':@brandingbrand\/react-native-app-auth'/g,
-        '\':react-native-app-auth\'');
-  
-      // 4) Write file
-      fs.writeFileSync(appBuildGradlePath, buildGradleContents);
-  
-      // add redirect schemes to AndroidManifest
-      let appManifestContents = fs.readFileSync(appManifestPath, 'utf8');
-      const appAuthReceiver = 'net.openid.appauth.RedirectUriReceiverActivity';
-      // look for receiver in manifest, and add if not there
-      if (appManifestContents.indexOf(appAuthReceiver) === -1) {
-        const receiverActivity = `
-        <activity
-          android:name="${appAuthReceiver}"
-          xmlns:tools="http://schemas.android.com/tools"
-                tools:node="replace">
-          ${redirectSchemes.map(scheme => {
-            return `
-              <intent-filter>
-                  <action android:name="android.intent.action.VIEW"/>
-                  <category android:name="android.intent.category.DEFAULT"/>
-                  <category android:name="android.intent.category.BROWSABLE"/>
-                  <data android:scheme="${scheme}"/>
-              </intent-filter>
-            `;
-          }).join('\n')}
-        </activity>`;
-        appManifestContents = appManifestContents.replace('</application>', receiverActivity + '\n</application>');
-  
-        fs.writeFileSync(appManifestPath, appManifestContents);
-      }
-  
-  
-      // clean up scoped package name in settings.gradle
-      let settingsGradleContents = fs.readFileSync(projectSettings, 'utf8');
-      settingsGradleContents = settingsGradleContents.replace(
-        /':@brandingbrand\/react-native-app-auth'/g,
-        '\':react-native-app-auth\'');
-      fs.writeFileSync(projectSettings, settingsGradleContents);  
+    // 2) Upgrade compile version
+    buildGradleContents = buildGradleContents.replace(
+      'compileSdkVersion 24', 
+      'compileSdkVersion 25');
+
+    // 3) fix scoped package name in app/build.gradle
+    buildGradleContents = buildGradleContents.replace(
+      /':@brandingbrand\/react-native-app-auth'/g,
+      '\':react-native-app-auth\'');
+
+    // 4) Write file
+    fs.writeFileSync(appBuildGradlePath, buildGradleContents);
+
+    // add redirect schemes to AndroidManifest
+    let appManifestContents = fs.readFileSync(appManifestPath, 'utf8');
+    const appAuthReceiver = 'net.openid.appauth.RedirectUriReceiverActivity';
+    // look for receiver in manifest, and add if not there
+    if (appManifestContents.indexOf(appAuthReceiver) === -1) {
+      const receiverActivity = `
+      <activity
+        android:name="${appAuthReceiver}"
+        xmlns:tools="http://schemas.android.com/tools"
+              tools:node="replace">
+        ${redirectSchemes.map(scheme => {
+          return `
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW"/>
+                <category android:name="android.intent.category.DEFAULT"/>
+                <category android:name="android.intent.category.BROWSABLE"/>
+                <data android:scheme="${scheme}"/>
+            </intent-filter>
+          `;
+        }).join('\n')}
+      </activity>`;
+      appManifestContents = appManifestContents.replace('</application>', receiverActivity + '\n</application>');
+
+      fs.writeFileSync(appManifestPath, appManifestContents);
     }
+
+
+    // clean up scoped package name in settings.gradle
+    let settingsGradleContents = fs.readFileSync(projectSettings, 'utf8');
+    settingsGradleContents = settingsGradleContents.replace(
+      /':@brandingbrand\/react-native-app-auth'/g,
+      '\':react-native-app-auth\'');
+    fs.writeFileSync(projectSettings, settingsGradleContents);  
+  }
   }

--- a/scripts/rnpm-postlink-android.js
+++ b/scripts/rnpm-postlink-android.js
@@ -3,59 +3,61 @@ const path = require('path');
 const appBuildGradlePath = path.join('android', 'app', 'build.gradle');
 const appManifestPath = path.join('android', 'app', 'src', 'main', 'AndroidManifest.xml');
 const projectSettings = path.join('android', 'settings.gradle');
-module.exports = function install(redirectSchemes) { 
+module.exports = function install(redirectSchemes) {
+    // If only initing iOS android won't exist
+    if (fs.existsSync(appBuildGradlePath)) {
+      let buildGradleContents = fs.readFileSync(appBuildGradlePath, 'utf8');
 
-    let buildGradleContents = fs.readFileSync(appBuildGradlePath, 'utf8');
-
-    // 1) Upgrade support version to 25.3.1
-    buildGradleContents = buildGradleContents.replace(
-      'com.android.support:appcompat-v7:23.0.1', 
-      'com.android.support:appcompat-v7:25.3.1');
-
-    // 2) Upgrade compile version
-    buildGradleContents = buildGradleContents.replace(
-      'compileSdkVersion 24', 
-      'compileSdkVersion 25');
-
-    // 3) fix scoped package name in app/build.gradle
-    buildGradleContents = buildGradleContents.replace(
-      /':@brandingbrand\/react-native-app-auth'/g,
-      '\':react-native-app-auth\'');
-
-    // 4) Write file
-    fs.writeFileSync(appBuildGradlePath, buildGradleContents);
-
-    // add redirect schemes to AndroidManifest
-    let appManifestContents = fs.readFileSync(appManifestPath, 'utf8');
-    const appAuthReceiver = 'net.openid.appauth.RedirectUriReceiverActivity';
-    // look for receiver in manifest, and add if not there
-    if (appManifestContents.indexOf(appAuthReceiver) === -1) {
-      const receiverActivity = `
-      <activity
-        android:name="${appAuthReceiver}"
-        xmlns:tools="http://schemas.android.com/tools"
-              tools:node="replace">
-        ${redirectSchemes.map(scheme => {
-          return `
-            <intent-filter>
-                <action android:name="android.intent.action.VIEW"/>
-                <category android:name="android.intent.category.DEFAULT"/>
-                <category android:name="android.intent.category.BROWSABLE"/>
-                <data android:scheme="${scheme}"/>
-            </intent-filter>
-          `;
-        }).join('\n')}
-      </activity>`;
-      appManifestContents = appManifestContents.replace('</application>', receiverActivity + '\n</application>');
-
-      fs.writeFileSync(appManifestPath, appManifestContents);
+      // 1) Upgrade support version to 25.3.1
+      buildGradleContents = buildGradleContents.replace(
+        'com.android.support:appcompat-v7:23.0.1', 
+        'com.android.support:appcompat-v7:25.3.1');
+  
+      // 2) Upgrade compile version
+      buildGradleContents = buildGradleContents.replace(
+        'compileSdkVersion 24', 
+        'compileSdkVersion 25');
+  
+      // 3) fix scoped package name in app/build.gradle
+      buildGradleContents = buildGradleContents.replace(
+        /':@brandingbrand\/react-native-app-auth'/g,
+        '\':react-native-app-auth\'');
+  
+      // 4) Write file
+      fs.writeFileSync(appBuildGradlePath, buildGradleContents);
+  
+      // add redirect schemes to AndroidManifest
+      let appManifestContents = fs.readFileSync(appManifestPath, 'utf8');
+      const appAuthReceiver = 'net.openid.appauth.RedirectUriReceiverActivity';
+      // look for receiver in manifest, and add if not there
+      if (appManifestContents.indexOf(appAuthReceiver) === -1) {
+        const receiverActivity = `
+        <activity
+          android:name="${appAuthReceiver}"
+          xmlns:tools="http://schemas.android.com/tools"
+                tools:node="replace">
+          ${redirectSchemes.map(scheme => {
+            return `
+              <intent-filter>
+                  <action android:name="android.intent.action.VIEW"/>
+                  <category android:name="android.intent.category.DEFAULT"/>
+                  <category android:name="android.intent.category.BROWSABLE"/>
+                  <data android:scheme="${scheme}"/>
+              </intent-filter>
+            `;
+          }).join('\n')}
+        </activity>`;
+        appManifestContents = appManifestContents.replace('</application>', receiverActivity + '\n</application>');
+  
+        fs.writeFileSync(appManifestPath, appManifestContents);
+      }
+  
+  
+      // clean up scoped package name in settings.gradle
+      let settingsGradleContents = fs.readFileSync(projectSettings, 'utf8');
+      settingsGradleContents = settingsGradleContents.replace(
+        /':@brandingbrand\/react-native-app-auth'/g,
+        '\':react-native-app-auth\'');
+      fs.writeFileSync(projectSettings, settingsGradleContents);  
     }
-
-
-    // clean up scoped package name in settings.gradle
-    let settingsGradleContents = fs.readFileSync(projectSettings, 'utf8');
-    settingsGradleContents = settingsGradleContents.replace(
-      /':@brandingbrand\/react-native-app-auth'/g,
-      '\':react-native-app-auth\'');
-    fs.writeFileSync(projectSettings, settingsGradleContents);
   }


### PR DESCRIPTION
When running flagship init ios and using react-native-app-auth in env build would error in linking process

Testing:
init ios sample project with react-native-app-auth in the env
linking should not produce an error and final build should run

init with flagship or android with correct env
linking should be done without error and final build should be done